### PR TITLE
get room owner on event 'room-join','room-topic'

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -218,7 +218,7 @@ export class Io {
 
         case 'update':
           log.verbose('Io', 'on(report): %s', ioEvent.payload)
-          const user = this.setting.wechaty.user()
+          const user = this.setting.wechaty.puppet ? this.setting.wechaty.puppet.user : null
           if (user) {
             const loginEvent: IoEvent = {
               name:       'login'

--- a/src/room.ts
+++ b/src/room.ts
@@ -39,6 +39,7 @@ export type RoomRawObj = {
   EncryChatRoomId:  string
   NickName:         string
   OwnerUin:         number
+  ChatRoomOwner:    string
   MemberList:       RoomRawMember[]
 }
 
@@ -337,9 +338,13 @@ export class Room extends EventEmitter implements Sayable {
     memberList = memberList.filter(m => m.get('uin') === ownerUin)
     if (memberList.length > 0) {
       return memberList[0]
-    } else {
-      return null
     }
+    
+    if(this.rawObj.ChatRoomOwner){
+      return Contact.load(this.rawObj.ChatRoomOwner)
+    }
+
+    return null
   }
 
   /**

--- a/src/room.ts
+++ b/src/room.ts
@@ -339,8 +339,8 @@ export class Room extends EventEmitter implements Sayable {
     if (memberList.length > 0) {
       return memberList[0]
     }
-    
-    if(this.rawObj.ChatRoomOwner){
+
+    if (this.rawObj.ChatRoomOwner) {
       return Contact.load(this.rawObj.ChatRoomOwner)
     }
 


### PR DESCRIPTION
issue 1: 

wxwebApp had hide uin of room members from some routing. so we can't get owner by using uin anymore: 

```javascript
memberList = memberList.filter(m => m.get('uin') === ownerUin)
     if (memberList.length > 0) {
       return memberList[0]
     } else {
       return null
     }
```

but on 'room-join' and 'room-topic' event ,we got a ``ChatRoomOwner```  property from rawObj, it can be used to load owner..
 
```javascript
rawObj:
   { Alias: '',
     AppAccountFlag: 0,
     AttrStatus: 0,
     ChatRoomId: 0,
     ChatRoomOwner: '@b261a88d4de1479cdf735c851fe22afe',
     City: '',
     ContactFlag: 2,
     DisplayName: '',
     EncryChatRoomId: '@dfee772e7d01ad0cfcdc5e2e8c81e558',
     HeadImgUpdateFlag: 1,
     HeadImgUrl: '/cgi-bin/mmwebwx-bin/webwxgetheadimg?seq=0&username=@@72317905edc07327e00aa61f690de1ea2a98117aca6ff32ddfe4eb0&skey=@crypt_9d729d2b_71e57bdd5f75
90fee74da393476f8160',
     HideInputBarFlag: 0,
     KeyWord: '',
     MMFromBatchGet: true,
     MMFromBatchget: true,
     MMInChatroom: true,
...
````
