### PR TITLE
#216 add AtBot event

### DIFF
--- a/src/puppet-web/event.ts
+++ b/src/puppet-web/event.ts
@@ -312,6 +312,11 @@ async function onServerMessage(this: PuppetWeb, obj: MsgRawObj): Promise<void> {
           Firer.checkFriendConfirm.call(this, m)
         }
         break
+
+      case MsgType.TEXT:
+        if (m.room() && this.user) {
+          Firer.checkMessageAt.call(this, m, this.user)
+        }
     }
 
     /**

--- a/src/puppet-web/firer.ts
+++ b/src/puppet-web/firer.ts
@@ -38,6 +38,8 @@ export const Firer = {
   , checkRoomLeave
   , checkRoomTopic
 
+  , checkMessageAt
+
   , parseFriendConfirm
   , parseRoomJoin
   , parseRoomLeave
@@ -70,6 +72,16 @@ const regexConfig = {
       /^"?(.+?)"? changed the group name to "(.+)"$/
     , /^"?(.+?)"?修改群名为“(.+)”$/
   ]
+}
+
+async function checkMessageAt(m: Message, user: Contact) {
+  const regConfig = new RegExp('@' + user.name())
+  if (regConfig.test(m.content())) {
+      const contact = m.from()
+      const content = m.content()
+      const room = m.room()
+      this.emit('message-at', contact, room, content)
+  }
 }
 
 async function checkFriendRequest(m: Message) {

--- a/src/wechaty.ts
+++ b/src/wechaty.ts
@@ -42,6 +42,7 @@ export type WechatyEventName = 'error'
                               | 'login'
                               | 'logout'
                               | 'message'
+                              | 'message-at'
                               | 'room-join'
                               | 'room-leave'
                               | 'room-topic'
@@ -171,6 +172,7 @@ export class Wechaty extends EventEmitter implements Sayable {
   public on(event: 'logout'     , listener: (this: Wechaty, user: Contact) => void): this
   public on(event: 'login'      , listener: (this: Wechaty, user: Contact) => void): this
   public on(event: 'message'    , listener: (this: Wechaty, message: Message) => void): this
+  public on(event: 'message-at' , listener: (this: Wechaty, contact: Contact, room: Room, content: string) => void): this
   public on(event: 'room-join'  , listener: (this: Wechaty, room: Room, inviteeList: Contact[],  inviter: Contact) => void): this
   public on(event: 'room-leave' , listener: (this: Wechaty, room: Room, leaverList: Contact[]) => void): this
   public on(event: 'room-topic' , listener: (this: Wechaty, room: Room, topic: string, oldTopic: string, changer: Contact) => void): this
@@ -223,6 +225,7 @@ export class Wechaty extends EventEmitter implements Sayable {
       , 'login'
       , 'logout'
       , 'message'
+      , 'message-at'
       , 'room-join'
       , 'room-leave'
       , 'room-topic'


### PR DESCRIPTION
I added an event called 'message-at', once the event is emitted, it will return:

 `who in where @bot said what`

the following code works well.

``` ts
.on('message-at', function(contact, room, content) {
  console.log('message-at event works!')
  console.log(contact)
  console.log(room)
  console.log(content)
  })
```