### PR TITLE
Fix async error handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "0.39.30",
+  "version": "0.39.31",
   "description": "Wechaty is a Bot SDK for Individual Account, Powered by TypeScript, Docker, and 💖",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "0.39.29",
+  "version": "0.39.30",
   "description": "Wechaty is a Bot SDK for Individual Account, Powered by TypeScript, Docker, and 💖",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/wechaty.spec.ts
+++ b/src/wechaty.spec.ts
@@ -149,6 +149,42 @@ test('on(event, Function)', async t => {
 
 })
 
+test('test async error', async (t) => {
+
+  // Do not modify the gloabl Wechaty instance
+  class MyWechatyTest extends Wechaty {}
+
+  const EXPECTED_ERROR = new Error('test')
+
+  const bot = new MyWechatyTest({
+    puppet: new PuppetMock(),
+  })
+
+  const asyncErrorFunction = function () {
+    return new Promise((resolve, reject) => {
+      setTimeout(function () {
+        reject(EXPECTED_ERROR)
+      }, 100)
+      // tslint ask resolve must be called,
+      // so write a fasly value, so that it never called
+      if (+new Date() < 0) {
+        resolve()
+      }
+    })
+  }
+
+  bot.on('message', async () => {
+    await asyncErrorFunction()
+  })
+  bot.on('error', (e) => {
+    t.ok(e.message === EXPECTED_ERROR.message)
+  })
+
+  bot.emit('message', {} as any)
+
+  await bot.stop()
+})
+
 test('use plugin', async (t) => {
 
   // Do not modify the gloabl Wechaty instance

--- a/src/wechaty.ts
+++ b/src/wechaty.ts
@@ -611,7 +611,7 @@ export class Wechaty extends EventEmitter implements Sayable {
     log.verbose('Wechaty', 'addListenerFunction(%s)', event)
 
     const handleError = (e: Error, type = '') => {
-      log.error('Wechaty', 'addListenerFunction(%s) listener %sexception: %s', event, type ? '' : (type + ''), e)
+      log.error('Wechaty', 'addListenerFunction(%s) listener %sexception: %s', event, type, e)
       this.emit('error', e)
     }
 
@@ -620,9 +620,9 @@ export class Wechaty extends EventEmitter implements Sayable {
      */
     super.on(event, (...args: any[]) => {
       try {
-        const rst = listener.apply(this, args)
-        if (rst && rst.catch && typeof rst.catch === 'function') {
-          rst.catch((e: Error) => handleError(e, 'async'))
+        const result = listener.apply(this, args)
+        if (result && result.catch && typeof result.catch === 'function') {
+          result.catch((e: Error) => handleError(e, 'async'))
         }
       } catch (e) {
         handleError(e)


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

https://github.com/wechaty/wechaty/blob/master/src/wechaty.ts#L618

This code doesn't handle async errors, which means they user have to write code like this, other wise the error will goes to unhandled promises.

```
bot.on('message', (m) => {
  try {
    // do all my works
  } catch(e) {
   // handle all my errors
  }
})
```


## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

This is going t break thing. the user's `emit('error')` may get more errors than before.

