### PR TITLE
docs: fixed table format flaw of `Contact.say` in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ All wechat contacts(friends/non-friends) will be encapsulated as a Contact.
 | static | [`load(query: string): Contact`](https://wechaty.github.io/wechaty/#Contact.load) | get contact by id |
 | property | `id: readonly string` | get contact id |
 | method | [`sync(): Promise<void>`](https://wechaty.github.io/wechaty/#Contact+sync) | force reload data for contact , sync data from lowlevel API again|
-| method | [`say(text: string): Promise<void | Message>`](https://wechaty.github.io/wechaty/#Contact+say) | send text, Contact, or file to contact, return the message which the bot sent (only `puppet-padplus` supported). |
+| method | [`say(text: string): Promise<void \| Message>`](https://wechaty.github.io/wechaty/#Contact+say) | send text, Contact, or file to contact, return the message which the bot sent (only `puppet-padplus` supported). |
 | method | [`self(): boolean`](https://wechaty.github.io/wechaty/#Contact+self) | check if contact is self |
 | method | [`name(): string`](https://wechaty.github.io/wechaty/#Contact+name) | get the name from a contact |
 | method | [`alias(): Promise<string>`](https://wechaty.github.io/wechaty/#Contact+alias) | get the alias for a contact |


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Hi Team,

Currently, the table of [`Class Contact`](https://github.com/wechaty/wechaty#2-class-contact) has a format flaw as shown below.

![image](https://user-images.githubusercontent.com/26999792/84618591-3f4e1300-af05-11ea-9f91-b6884d15de49.png)

We should add a escape character `\` between `void` and `Message`.

The expected is

![image](https://user-images.githubusercontent.com/26999792/84618967-56413500-af06-11ea-937b-07342377e7aa.png)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

