### PR TITLE
Split to trunks when making requests of room.findAll() and room.ready()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "0.48.10",
+  "version": "0.48.11",
   "description": "Wechaty is Conversational SDK Chatbot Makers, Powered by TypeScript, Docker, and 💖",
   "main": "dist/src/mod.js",
   "typings": "dist/src/mod.d.ts",

--- a/src/user/room.ts
+++ b/src/user/room.ts
@@ -130,22 +130,34 @@ class Room extends RoomEventEmitter implements Sayable {
   ): Promise<Array<T['prototype']>> {
     log.verbose('Room', 'findAll(%s)', JSON.stringify(query) || '')
 
-    const invalidDict: { [id: string]: true } = {}
-
     try {
       const roomIdList = await this.wechaty.puppet.roomSearch(query)
       const roomList = roomIdList.map(id => this.load(id))
-      await Promise.all(
-        roomList.map(
-          room => room.ready()
-            .catch(e => {
-              log.warn('Room', 'findAll() room.ready() rejection: %s', e)
-              invalidDict[room.id] = true
-            })
-        ),
-      )
 
-      return roomList.filter(room => !invalidDict[room.id])
+      const BATCH_SIZE = 10
+      let   batchIndex = 0
+
+      const invalidSet: Set<string> = new Set()
+      while (batchIndex * BATCH_SIZE < roomList.length) {
+        const batchRoomList = roomList.slice(
+          BATCH_SIZE * batchIndex,
+          BATCH_SIZE * (batchIndex + 1),
+        )
+
+        await Promise.all(
+          batchRoomList.map(
+            room => room.ready()
+              .catch(e => {
+                log.warn('Room', 'findAll() room.ready() rejection:\n%s', e.stack)
+                invalidSet.add(room.id)
+              })
+          ),
+        )
+
+        batchIndex++
+      }
+
+      return roomList.filter(room => !invalidSet.has(room.id))
 
     } catch (e) {
       log.verbose('Room', 'findAll() rejected: %s', e.message)
@@ -342,16 +354,24 @@ class Room extends RoomEventEmitter implements Sayable {
 
     const memberIdList = await this.wechaty.puppet.roomMemberList(this.id)
 
-    await Promise.all(
-      memberIdList
-        .map(id => this.wechaty.Contact.load(id))
-        .map(contact => {
-          contact.ready()
-            .catch(e => {
-              log.verbose('Room', 'ready() member.ready() rejection: %s', e)
-            })
-        }),
-    )
+    const memberList = memberIdList.map(id => this.wechaty.Contact.load(id))
+
+    const BATCH_SIZE = 16
+    let   batchIndex = 0
+
+    while (batchIndex * BATCH_SIZE < memberList.length) {
+      const batchMemberList = memberList.slice(
+        BATCH_SIZE * batchIndex,
+        BATCH_SIZE * (batchIndex + 1),
+      )
+      await Promise.all(
+        batchMemberList.map(
+          c => c.ready().catch(e => log.error('Room', 'ready() member.ready() exception:\n%s', e.stack))
+        ),
+      )
+
+      batchIndex++
+    }
   }
 
   /**


### PR DESCRIPTION
## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] CI has been passed. (GitHub actions all turns green)
- [x] SLA has been signed

## Description

This is related to issue: https://github.com/wechaty/wechaty/issues/2068
