### PR TITLE
use find() to replace load()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {
@@ -110,6 +110,7 @@
     "clone-class": "^1.0.2",
     "cockatiel": "^2.0.2",
     "dotenv": "^10.0.0",
+    "gerror": "^1.0.2",
     "json-rpc-peer": "^0.17.0",
     "open-graph": "^0.2.6",
     "state-switch": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Wechaty is a RPA SDK for Chatbot Makers.",
   "type": "module",
   "exports": {

--- a/src/interface/wechaty-interface.spec.ts
+++ b/src/interface/wechaty-interface.spec.ts
@@ -22,8 +22,13 @@ import type {
 import type {
   WechatyConstructor,
   Wechaty,
+  WechatyProtectedProperty,
   // WechatyConstructor,
 }                       from './wechaty-interface.js'
+
+import type {
+  WechatyImpl,
+}                       from '../wechaty.js'
 
 test('Wechaty interface', async t => {
   abstract class WechatyImplementation extends EventEmitter implements Wechaty {
@@ -37,7 +42,7 @@ test('Wechaty interface', async t => {
     MiniProgram    : MiniProgramConstructor
     Room           : RoomConstructor
     RoomInvitation : RoomInvitationConstructor
-    Delay        : DelayConstructor
+    Delay          : DelayConstructor
     Tag            : TagConstructor
     UrlLink        : UrlLinkConstructor
 
@@ -90,4 +95,12 @@ test('Wechaty interface', async t => {
   })
 
   t.ok(typeof WechatyImplementation, 'should no typing error')
+})
+
+test('ProtectedProperties', async t => {
+  type NotExistInWechaty = Exclude<WechatyProtectedProperty, keyof WechatyImpl>
+  type NotExistTest = NotExistInWechaty extends never ? true : false
+
+  const noOneLeft: NotExistTest = true
+  t.ok(noOneLeft, 'should match Wechaty properties for every protected property')
 })

--- a/src/interface/wechaty-interface.ts
+++ b/src/interface/wechaty-interface.ts
@@ -6,35 +6,42 @@ import type { WechatyImpl }             from '../wechaty.js'
 import type { WechatyEventListeners } from '../events/wechaty-events.js'
 import type TypedEventEmitter from 'typed-emitter'
 
-type DeprecatedProperties = never
+type DeprecatedProperties =
   | 'userSelf'
 
-type NonInterfaceProperties = never
+type NonInterfaceProperties =
   | 'log'
-  | 'options'
-  | '_pluginUninstallerList'
-  | '_readyState'
+  // | 'options'
+  // | '_pluginUninstallerList'
+  // | '_readyState'
   | 'wechaty'
   | 'onStart'
   | 'onStop'
-  | '_serviceCtlFsmInterpreter'     // from ServiceCtlFsm
+  // | '_serviceCtlFsmInterpreter'     // from ServiceCtlFsm
   | '_serviceCtlLogger'             // from ServiceCtl(&Fsm)
   | '_serviceCtlResettingIndicator' // from ServiceCtl
 
 // https://stackoverflow.com/a/64754408/1123955
-type KeyOfWechaty       = keyof WechatyImpl
-// Huan(202110): remove all EventEmitter first, or will get error
-type KeyOfEventEmitter  = keyof EventEmitter
+// type KeyOfWechaty       = keyof WechatyImpl
 
-type PublicProperties = Exclude<KeyOfWechaty, never
+// type KeyOfEventEmitter  = keyof EventEmitter
+
+type WechatyProtectedProperty =
   | DeprecatedProperties
-  | KeyOfEventEmitter
+  | keyof EventEmitter  // Huan(202110): remove all EventEmitter first, and added typed event emitter later: or will get error
   | NonInterfaceProperties
-  // | WechatyUserClass
->
+
+// type PublicProperties = Exclude<KeyOfWechaty, never
+//   | DeprecatedProperties
+//   | KeyOfEventEmitter
+//   | NonInterfaceProperties
+// >
 
 // https://stackoverflow.com/questions/41926269/naming-abstract-classes-and-interfaces-in-typescript
-type Wechaty = Pick<WechatyImpl, PublicProperties>
+// type Wechaty2 = Pick<WechatyImpl, PublicProperties>
+//   & TypedEventEmitter<WechatyEventListeners>
+
+type Wechaty = Omit<WechatyImpl, WechatyProtectedProperty>
   & TypedEventEmitter<WechatyEventListeners>
 
 type WechatyConstructor = Constructor<
@@ -45,4 +52,5 @@ type WechatyConstructor = Constructor<
 export type {
   Wechaty,
   WechatyConstructor,
+  WechatyProtectedProperty,
 }

--- a/src/user/contact-self.ts
+++ b/src/user/contact-self.ts
@@ -192,7 +192,7 @@ class ContactSelfImpl extends validationMixin(ContactSelfMixin)<ContactSelf>() {
 interface ContactSelf extends ContactSelfImpl {}
 type ContactSelfConstructor = Constructor<
   ContactSelf,
-  typeof ContactSelfImpl
+  Omit<typeof ContactSelfImpl, 'load'>
 >
 
 export type {

--- a/src/user/contact.spec.ts
+++ b/src/user/contact.spec.ts
@@ -27,7 +27,10 @@ import type * as PUPPET from 'wechaty-puppet'
 import { PuppetMock } from 'wechaty-puppet-mock'
 import { WechatyBuilder } from '../wechaty-builder.js'
 
-import { ContactImpl }  from './contact.js'
+import {
+  ContactImpl,
+  ContactProtectedProperty,
+}                             from './contact.js'
 
 test('findAll()', async t => {
   const EXPECTED_CONTACT_ID      = 'test-id'
@@ -88,4 +91,12 @@ test('should throw when instanciate the global class', async t => {
     t.fail('should not run to here')
     t.fail(c.toString())
   }, 'should throw when we instanciate a global class')
+})
+
+test('ProtectedProperties', async t => {
+  type NotExistInWechaty = Exclude<ContactProtectedProperty, keyof ContactImpl>
+  type NotExistTest = NotExistInWechaty extends never ? true : false
+
+  const noOneLeft: NotExistTest = true
+  t.ok(noOneLeft, 'should match Wechaty properties for every protected property')
 })

--- a/src/user/contact.ts
+++ b/src/user/contact.ts
@@ -174,7 +174,7 @@ class ContactMixin extends MixinBase implements Sayable {
         )
 
         /**
-         * Huan(202110): use a interator with works to control the concurrency of Promise.all.
+         * Huan(202110): use an iterator with works to control the concurrency of Promise.all.
          *  @see https://stackoverflow.com/a/51020535/1123955
          */
 

--- a/src/user/friendship.ts
+++ b/src/user/friendship.ts
@@ -32,6 +32,7 @@ import { log } from '../config.js'
 
 import type {
   Contact,
+  ContactImpl,
 }                       from './contact.js'
 import type {
   Room,
@@ -105,8 +106,7 @@ class FriendshipMixin extends MixinBase implements Acceptable {
       return undefined
     }
 
-    const contact = this.wechaty.Contact.load(contactId)
-    await contact.ready()
+    const contact = await this.wechaty.Contact.find({ id: contactId })
     return contact
   }
 
@@ -216,7 +216,7 @@ class FriendshipMixin extends MixinBase implements Acceptable {
     //   throw new Error('no payload')
     // }
 
-    await this.contact().ready()
+    await (this.contact() as ContactImpl).ready()
   }
 
   /**
@@ -268,7 +268,7 @@ class FriendshipMixin extends MixinBase implements Acceptable {
 
     try {
       const doSync = async () => {
-        await contact.ready()
+        await (contact as ContactImpl).ready()
         if (!contact.isReady()) {
           throw new Error('Friendship.accept() contact.ready() not ready')
         }
@@ -330,7 +330,7 @@ class FriendshipMixin extends MixinBase implements Acceptable {
       throw new Error('no payload')
     }
 
-    const contact = this.wechaty.Contact.load(this._payload.contactId)
+    const contact = (this.wechaty.Contact as typeof ContactImpl).load(this._payload.contactId)
     return contact
   }
 

--- a/src/user/message.spec.ts
+++ b/src/user/message.spec.ts
@@ -27,6 +27,10 @@ import {
 import * as PUPPET        from 'wechaty-puppet'
 import { PuppetMock }     from 'wechaty-puppet-mock'
 import { WechatyBuilder } from '../wechaty-builder.js'
+import type {
+  MessageImpl,
+  MessageProtectedProperty,
+}                           from './message.js'
 
 test('recalled()', async t => {
 
@@ -88,8 +92,11 @@ test('recalled()', async t => {
 
   await puppet.login(EXPECTED_TO_CONTACT_ID)
 
-  const message = wechaty.Message.load(EXPECTED_RECALL_MESSAGE_ID)
-  await message.ready()
+  const message = await wechaty.Message.find({ id: EXPECTED_RECALL_MESSAGE_ID })
+  if (!message) {
+    throw new Error('message not found')
+  }
+  // await message.ready()
   const recalledMessage = await message.toRecalled()
   t.ok(recalledMessage, 'recalled message should exist.')
   t.equal(recalledMessage!.id, EXPECTED_RECALLED_MESSAGE_ID, 'Recalled message should have the right id.')
@@ -98,4 +105,12 @@ test('recalled()', async t => {
   t.equal(recalledMessage!.room()!.id, EXPECTED_ROOM_ID, 'Recalled message should have the right room id.')
 
   await wechaty.stop()
+})
+
+test('ProtectedProperties', async t => {
+  type NotExistInWechaty = Exclude<MessageProtectedProperty, keyof MessageImpl>
+  type NotExistTest = NotExistInWechaty extends never ? true : false
+
+  const noOneLeft: NotExistTest = true
+  t.ok(noOneLeft, 'should match Wechaty properties for every protected property')
 })

--- a/src/user/message.spec.ts
+++ b/src/user/message.spec.ts
@@ -90,13 +90,20 @@ test('recalled()', async t => {
     } as PUPPET.payload.Contact
   })
 
+  const fakeIdSearcher = async (...args: any[]) => {
+    await new Promise(setImmediate)
+    return [args[0].id]
+  }
+
+  sandbox.stub(puppet, 'messageSearch').callsFake(fakeIdSearcher)
+  sandbox.stub(puppet, 'contactSearch').callsFake(fakeIdSearcher)
+
   await puppet.login(EXPECTED_TO_CONTACT_ID)
 
   const message = await wechaty.Message.find({ id: EXPECTED_RECALL_MESSAGE_ID })
   if (!message) {
-    throw new Error('message not found')
+    throw new Error('no message for id: ' + EXPECTED_RECALL_MESSAGE_ID)
   }
-  // await message.ready()
   const recalledMessage = await message.toRecalled()
   t.ok(recalledMessage, 'recalled message should exist.')
   t.equal(recalledMessage!.id, EXPECTED_RECALLED_MESSAGE_ID, 'Recalled message should have the right id.')

--- a/src/user/message.ts
+++ b/src/user/message.ts
@@ -262,7 +262,7 @@ class MessageMixin extends MixinBase implements Sayable {
     if (!talkerId) {
       // Huan(202011): It seems that the fromId will never be null?
       // return null
-      throw new Error('payload.fromId is null?')
+      throw new Error('no payload.fromId found for talker')
     }
 
     let talker

--- a/src/user/room.spec.ts
+++ b/src/user/room.spec.ts
@@ -69,11 +69,11 @@ test('say()', async () => {
 
   await wechaty.start()
 
-  const EXPECTED_ROOM_ID = 'roomId'
-  const EXPECTED_ROOM_TOPIC = 'test-topic'
-  const EXPECTED_CONTACT_1_ID = 'contact1'
+  const EXPECTED_ROOM_ID         = 'roomId'
+  const EXPECTED_ROOM_TOPIC      = 'test-topic'
+  const EXPECTED_CONTACT_1_ID    = 'contact1'
   const EXPECTED_CONTACT_1_ALIAS = 'little1'
-  const EXPECTED_CONTACT_2_ID = 'contact2'
+  const EXPECTED_CONTACT_2_ID    = 'contact2'
   const EXPECTED_CONTACT_2_ALIAS = 'big2'
   const CONTACT_MAP: { [contactId: string]: string } = {}
   CONTACT_MAP[EXPECTED_CONTACT_1_ID] = EXPECTED_CONTACT_1_ALIAS
@@ -100,6 +100,13 @@ test('say()', async () => {
   })
   // sandbox.spy(puppet, 'messageSendText')
   sandbox.stub(puppet, 'messageSendText').callsFake(callback)
+
+  const fakeIdSearcher = async (...args: any[]) => {
+    await new Promise(setImmediate)
+    return [args[0].id]
+  }
+  sandbox.stub(puppet, 'contactSearch').callsFake(fakeIdSearcher)
+  sandbox.stub(puppet, 'roomSearch').callsFake(fakeIdSearcher)
 
   const room = await wechaty.Room.find({ id: EXPECTED_ROOM_ID })
   const contact1 = await wechaty.Contact.find({ id: EXPECTED_CONTACT_1_ID })

--- a/src/user/room.spec.ts
+++ b/src/user/room.spec.ts
@@ -27,6 +27,10 @@ import type * as PUPPET from 'wechaty-puppet'
 import { PuppetMock }   from 'wechaty-puppet-mock'
 
 import { WechatyBuilder } from '../wechaty-builder.js'
+import type {
+  RoomImpl,
+  RoomProtectedProperty,
+}                         from './room.js'
 
 test('findAll()', async t => {
   const EXPECTED_ROOM_ID      = 'test-id'
@@ -97,12 +101,16 @@ test('say()', async () => {
   // sandbox.spy(puppet, 'messageSendText')
   sandbox.stub(puppet, 'messageSendText').callsFake(callback)
 
-  const room = wechaty.Room.load(EXPECTED_ROOM_ID)
-  const contact1 = wechaty.Contact.load(EXPECTED_CONTACT_1_ID)
-  const contact2 = wechaty.Contact.load(EXPECTED_CONTACT_2_ID)
-  await contact1.sync()
-  await contact2.sync()
-  await room.sync()
+  const room = await wechaty.Room.find({ id: EXPECTED_ROOM_ID })
+  const contact1 = await wechaty.Contact.find({ id: EXPECTED_CONTACT_1_ID })
+  const contact2 = await wechaty.Contact.find({ id: EXPECTED_CONTACT_2_ID })
+
+  if (!room || !contact1 || !contact2) {
+    throw new Error('find by id: not found')
+  }
+  // await contact1.sync()
+  // await contact2.sync()
+  // await room.sync()
 
   test('say with Tagged Template', async t => {
     callback.resetHistory()
@@ -141,4 +149,12 @@ test('say()', async () => {
   })
 
   await wechaty.stop()
+})
+
+test('ProtectedProperties', async t => {
+  type NotExistInWechaty = Exclude<RoomProtectedProperty, keyof RoomImpl>
+  type NotExistTest = NotExistInWechaty extends never ? true : false
+
+  const noOneLeft: NotExistTest = true
+  t.ok(noOneLeft, 'should match Wechaty properties for every protected property')
 })

--- a/src/wechaty.spec.ts
+++ b/src/wechaty.spec.ts
@@ -308,7 +308,7 @@ test('ready()', async t => {
   await wechaty.stop()
 })
 
-test('on/off event listener management', async t => {
+test.only('on/off event listener management', async t => {
   const puppet = new PuppetMock()
   const wechaty = new WechatyImpl({ puppet })
 
@@ -317,10 +317,10 @@ test('on/off event listener management', async t => {
 
   wechaty.on('message', onMessage)
   t.equal(wechaty.listenerCount('message'), 1, 'should +1 listener after on(message)')
-
+  await new Promise(setImmediate)
   wechaty.off('message', onMessage)
+  await new Promise(setImmediate)
   t.equal(wechaty.listenerCount('message'), 0, 'should -1 listener after off(message)')
-
 })
 
 test('wrapAsync() async function', async t => {

--- a/src/wechaty.spec.ts
+++ b/src/wechaty.spec.ts
@@ -308,7 +308,7 @@ test('ready()', async t => {
   await wechaty.stop()
 })
 
-test.only('on/off event listener management', async t => {
+test('on/off event listener management', async t => {
   const puppet = new PuppetMock()
   const wechaty = new WechatyImpl({ puppet })
 
@@ -317,9 +317,8 @@ test.only('on/off event listener management', async t => {
 
   wechaty.on('message', onMessage)
   t.equal(wechaty.listenerCount('message'), 1, 'should +1 listener after on(message)')
-  await new Promise(setImmediate)
+
   wechaty.off('message', onMessage)
-  await new Promise(setImmediate)
   t.equal(wechaty.listenerCount('message'), 0, 'should -1 listener after off(message)')
 })
 

--- a/src/wechaty.ts
+++ b/src/wechaty.ts
@@ -90,7 +90,7 @@ import {
   UrlLinkConstructor,
   LocationConstructor,
 
-  // Contact,
+  Contact,
   ContactSelf,
   // Friendship,
   // Image,
@@ -394,7 +394,7 @@ class WechatyImpl extends mixinBase implements Sayable {
       this.listenerCount(event),
     )
 
-    return super.on(event, listener)
+    return super.on(event, this.wrapAsync(listener))
   }
 
   /**
@@ -525,9 +525,11 @@ class WechatyImpl extends mixinBase implements Sayable {
 
         case 'login':
           puppet.on('login', async payload => {
-            const contact = this.ContactSelf.load(payload.contactId)
             try {
-              await contact.ready()
+              const contact = await this.ContactSelf.find({ id: payload.contactId })
+              if (!contact) {
+                throw new Error('no contact found for id: ' + payload.contactId)
+              }
               this.emit('login', contact)
             } catch (e) {
               this.emit('error', e)
@@ -537,9 +539,11 @@ class WechatyImpl extends mixinBase implements Sayable {
 
         case 'logout':
           puppet.on('logout', async payload => {
-            const contact = this.ContactSelf.load(payload.contactId)
             try {
-              await contact.ready()
+              const contact = await this.ContactSelf.find({ id: payload.contactId })
+              if (!contact) {
+                throw new Error('no self contact for id: ' + payload.contactId)
+              }
               this.emit('logout', contact, payload.data)
             } catch (e) {
               this.emit('error', e)
@@ -549,9 +553,11 @@ class WechatyImpl extends mixinBase implements Sayable {
 
         case 'message':
           puppet.on('message', async payload => {
-            const msg = this.Message.load(payload.messageId)
             try {
-              await msg.ready()
+              const msg = await this.Message.find({ id: payload.messageId })
+              if (!msg) {
+                throw new Error('message not found for id: ' + payload.messageId)
+              }
               this.emit('message', msg)
 
               const room     = msg.room()
@@ -588,15 +594,23 @@ class WechatyImpl extends mixinBase implements Sayable {
 
         case 'room-join':
           puppet.on('room-join', async payload => {
-            const room = this.Room.load(payload.roomId)
             try {
+              const room = await this.Room.find({ id: payload.roomId })
+              if (!room) {
+                throw new Error('no room found for id: ' + payload.roomId)
+              }
               await room.sync()
 
-              const inviteeList = payload.inviteeIdList.map(id => this.Contact.load(id))
-              await Promise.all(inviteeList.map(c => c.ready()))
+              const inviteeListAll = await Promise.all(
+                payload.inviteeIdList.map(id => this.Contact.find({ id })),
+              )
+              const inviteeList = inviteeListAll.filter(c => !!c) as Contact[]
 
-              const inviter = this.Contact.load(payload.inviterId)
-              await inviter.ready()
+              const inviter = await this.Contact.find({ id: payload.inviterId })
+              if (!inviter) {
+                throw new Error('no inviter found for id: ' + payload.inviterId)
+              }
+
               const date = timestampToDate(payload.timestamp)
 
               this.emit('room-join', room, inviteeList, inviter, date)
@@ -610,18 +624,25 @@ class WechatyImpl extends mixinBase implements Sayable {
         case 'room-leave':
           puppet.on('room-leave', async payload => {
             try {
-              const room = this.Room.load(payload.roomId)
+              const room = await this.Room.find({ id: payload.roomId })
+              if (!room) {
+                throw new Error('no room found for id: ' + payload.roomId)
+              }
 
               /**
                * See: https://github.com/wechaty/wechaty/pull/1833
                */
               await room.sync()
 
-              const leaverList = payload.removeeIdList.map(id => this.Contact.load(id))
-              await Promise.all(leaverList.map(c => c.ready()))
+              const leaverListAll = await Promise.all(
+                payload.removeeIdList.map(id => this.Contact.find({ id })),
+              )
+              const leaverList = leaverListAll.filter(c => !!c) as Contact[]
 
-              const remover = this.Contact.load(payload.removerId)
-              await remover.ready()
+              const remover = await this.Contact.find({ id: payload.removerId })
+              if (!remover) {
+                throw new Error('no remover found for id: ' + payload.removerId)
+              }
               const date = timestampToDate(payload.timestamp)
 
               this.emit('room-leave', room, leaverList, remover, date)
@@ -641,11 +662,16 @@ class WechatyImpl extends mixinBase implements Sayable {
         case 'room-topic':
           puppet.on('room-topic', async payload => {
             try {
-              const room = this.Room.load(payload.roomId)
+              const room = await this.Room.find({ id: payload.roomId })
+              if (!room) {
+                throw new Error('no room found for id: ' + payload.roomId)
+              }
               await room.sync()
 
-              const changer = this.Contact.load(payload.changerId)
-              await changer.ready()
+              const changer = await this.Contact.find({ id: payload.changerId })
+              if (!changer) {
+                throw new Error('no changer found for id: ' + payload.changerId)
+              }
               const date = timestampToDate(payload.timestamp)
 
               this.emit('room-topic', room, payload.newTopic, payload.oldTopic, changer, date)
@@ -675,10 +701,10 @@ class WechatyImpl extends mixinBase implements Sayable {
               switch (payloadType) {
                 case PUPPET.type.Payload.RoomMember:
                 case PUPPET.type.Payload.Contact:
-                  await this.Contact.load(payloadId).sync()
+                  await (await this.Contact.find({ id: payloadId }))?.sync()
                   break
                 case PUPPET.type.Payload.Room:
-                  await this.Room.load(payloadId).sync()
+                  await (await this.Room.find({ id: payloadId }))?.sync()
                   break
 
                 /**
@@ -754,17 +780,20 @@ class WechatyImpl extends mixinBase implements Sayable {
       return super.emit(event, ...args)
     }
 
-    const data = args[0]
-    let gerr: GError
+    /**
+     * Dealing with the `error` event
+     */
+    const arg0 = args[0]
+    let gerror: GError
 
-    if (data instanceof GError) {
-      gerr = data
+    if (arg0 instanceof GError) {
+      gerror = arg0
     } else {
-      gerr = GError.from(data)
+      gerror = GError.from(arg0)
     }
 
-    captureException(gerr)
-    return super.emit('error', gerr)
+    captureException(gerror)
+    return super.emit('error', gerror)
   }
 
   override async onStart (): Promise<void> {
@@ -905,7 +934,7 @@ class WechatyImpl extends mixinBase implements Sayable {
    */
   currentUser (): ContactSelf {
     const userId = this.puppet.currentUserId
-    const user = this.ContactSelf.load(userId)
+    const user = (this.ContactSelf as typeof ContactSelfImpl).load(userId)
     return user
   }
 

--- a/src/wechaty.ts
+++ b/src/wechaty.ts
@@ -26,6 +26,8 @@ import {
 }                       from 'memory-card'
 import {
   GError,
+  WrapAsync,
+  wrapAsyncError,
 }                       from 'gerror'
 import {
   StateSwitch,
@@ -326,7 +328,7 @@ class WechatyImpl extends mixinBase implements Sayable {
    *    by catcing any errors and emit them to error event
    *  2. wrap a Promise by catcing any errors and emit them to error event
    */
-  wrapAsync: PUPPET.helper.WrapAsync = PUPPET.helper.wrapAsyncError((e: any) => this.emit('error', e))
+  wrapAsync: WrapAsync = wrapAsyncError((e: any) => this.emit('error', e))
 
   /**
    * Creates an instance of Wechaty.
@@ -394,7 +396,7 @@ class WechatyImpl extends mixinBase implements Sayable {
       this.listenerCount(event),
     )
 
-    return super.on(event, this.wrapAsync(listener))
+    return super.on(event, listener)
   }
 
   /**


### PR DESCRIPTION
We have hidden the `load()` API in Wechaty v1.0.

Use `find()` when you need call `load()`.

Implements:

- #2289 