### PR TITLE
feat: support uos in io-client for Puppet Service

### DIFF
--- a/bin/io-client.ts
+++ b/bin/io-client.ts
@@ -61,7 +61,16 @@ async function main () {
   console.info(welcome)
   log.info('Client', 'Starting for WECHATY_TOKEN: %s', token)
 
-  const wechaty = WechatyBuilder.build({ name: token })
+  const uosEnabled = process.env['WECHATY_PUPPET_WECHAT_UOS_ENABLE'] === 'true'
+  if (uosEnabled) {
+    log.info('Client', 'Enable UOS support for WECHATY_PUPPET_WECHAT')
+  }
+  const wechaty = WechatyBuilder.build({
+    name: token,
+    puppetOptions: {
+      uos: uosEnabled,
+    },
+  })
 
   let port
   if (process.env['WECHATY_PUPPET_SERVER_PORT']) {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "wechaty-puppet": "^1.20.1",
     "wechaty-puppet-service": "^1.19.8",
     "wechaty-puppet-wechat4u": "^1.11.1",
+    "wechaty-puppet-wechat": "^1.18.4",
     "wechaty-token": "^1.1.1",
     "ws": "^8.5.0"
   },

--- a/src/puppet-config.ts
+++ b/src/puppet-config.ts
@@ -51,7 +51,7 @@ const OFFICIAL_PUPPET_DEPENDENCIES = {
   /**
    * WeChat Puppets
    */
-  'wechaty-puppet-wechat'           : '>=1.11.8', // https://www.npmjs.com/package/wechaty-puppet-wechat
+  'wechaty-puppet-wechat'           : '>=1.18.4', // https://www.npmjs.com/package/wechaty-puppet-wechat
   'wechaty-puppet-wechat4u'         : '>=1.11.1', // https://www.npmjs.com/package/wechaty-puppet-wechat4u
   'wechaty-puppet-padlocal'         : '>=1.11.13',  // https://www.npmjs.com/package/wechaty-puppet-padlocal
   'wechaty-puppet-xp'               : '>=1.10.2',  // https://www.npmjs.com/package/wechaty-puppet-xp


### PR DESCRIPTION
## Checklist

- [x ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added
- [ ] CI has been passed. (GitHub actions all turns green)
- [ ] CLA has been signed

## Description

> please describe the changes that you are making, with the related issue number.

From those blogs, we can see that wechaty web(uos) is working again.
[Wechaty Gateway 使用教程](https://wechaty.js.org/2022/06/23/wechaty-gateway-use/?q=service)
[Puppet Service: DIY](https://wechaty.js.org/docs/puppet-services/diy/#all-in-one-command)
[免费UOS协议快速接入可视化配置面板](https://wechaty.js.org/2022/07/26/free-uos-ui/)

But I see from the commit, uos feature is disabled by default, and the version of PUPPET_WECHAT must be greater or equal than 1.18.4
https://github.com/wechaty/puppet-wechat/pull/206
