### PR TITLE
feat: 🎸 message reply

### DIFF
--- a/src/user-modules/message.ts
+++ b/src/user-modules/message.ts
@@ -72,6 +72,7 @@ import {
 
 import { validationMixin } from '../user-mixins/validation.js'
 import type { ContactSelfImpl } from './contact-self.js'
+import { Post } from 'wechaty-puppet/types'
 
 const MixinBase = wechatifyMixin(
   EventEmitter,
@@ -1081,6 +1082,27 @@ class MessageMixin extends MixinBase implements SayableSayer {
   async toSayable (): Promise<undefined | Sayable> {
     log.verbose('Message', 'toSayable()')
     return messageToSayable(this)
+  }
+
+  async reply (
+    sayable: Sayable,
+  ): Promise<void | MessageInterface> {
+    log.verbose('Message', 'reply(%s)', sayable)
+
+    const builder = this.wechaty.Post.builder()
+    builder.type(Post.Message)
+    builder.reply(await this.toPost())
+    builder.add(sayable)
+    const post = await builder.build()
+
+    const talker  = this.talker()
+    const room    = this.room()
+
+    if (room) {
+      return room.say(post)
+    } else {
+      return talker.say(post)
+    }
   }
 
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c398075</samp>

Added a `reply` method to `MessageMixin` to support replying to messages. The method uses the `wechaty-puppet` `Post` type to create and send the reply.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c398075</samp>

> _Sing, O Muse, of the skillful `MessageMixin`,_
> _That grants the power of reply to the swift messages,_
> _As they fly through the air like winged arrows of Apollo,_
> _Or like Hermes, who bears the golden staff of `Post`._

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c398075</samp>

*  Import `Post` type from `wechaty-puppet` to use for replying messages ([link](https://github.com/wechaty/wechaty/pull/2534/files?diff=unified&w=0#diff-e1f2be6d124987fdd8237939cb04e6bb66e616e2edd7993e2ec9ccd07948c5aeR75))
*  Add `reply` method to `MessageMixin` class to allow a message to reply to another message with various content types ([link](https://github.com/wechaty/wechaty/pull/2534/files?diff=unified&w=0#diff-e1f2be6d124987fdd8237939cb04e6bb66e616e2edd7993e2ec9ccd07948c5aeR1087-R1107))

https://github.com/wechaty/wechaty/issues/2387

syntactic sugar for
```ts
wechaty.on('message', async msg => {
	const messagePost = msg.toPost()
	const post = bot.Post.builder()
	post.add('This is reply msg')
	post.reply(messagePost)
	post.type(PostType.Message)
	message.say(await post.build())
})
```