### PR TITLE
Add escapeRegExp tests

### DIFF
--- a/src/pure-functions/escape-regexp.spec.ts
+++ b/src/pure-functions/escape-regexp.spec.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+/**
+ *   Wechaty Chatbot SDK - https://github.com/wechaty/wechaty
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+import { test } from 'tstest'
+
+import { escapeRegExp } from './escape-regexp.js'
+
+test('escapeRegExp() with typical string', async t => {
+  const input = 'hello world'
+  const output = escapeRegExp(input)
+  t.equal(output, input, 'should keep typical strings unchanged')
+})
+
+test('escapeRegExp() escapes regex characters', async t => {
+  const input = '.*+?^${}()|[]\\'
+  const expected = '\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\'
+  const output = escapeRegExp(input)
+  t.equal(output, expected, 'should escape regex special characters with backslashes')
+})


### PR DESCRIPTION
## Summary
- add unit tests for `escapeRegExp`

## Testing
- `npm run test:unit` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685118b4466c8324a7b93ba6fbedaced